### PR TITLE
chore: export getOpenAIMessageParamFromMessage

### DIFF
--- a/packages/openai/src/_unsafeUtils.ts
+++ b/packages/openai/src/_unsafeUtils.ts
@@ -1,0 +1,47 @@
+import { GPTOptions, Message, MessageInput } from "./types.js";
+
+export const getMessageFromInput = <Options extends GPTOptions>(
+  message: MessageInput<Options>,
+): Message => {
+  if (typeof message === "string") {
+    return {
+      role: "user" as const,
+      strings: [message],
+      children: [],
+    };
+  }
+  if ("_isGptString" in message) {
+    return {
+      role: "user" as const,
+      strings: [],
+      children: [message],
+    };
+  }
+  if (
+    typeof message.content === "function" &&
+    "_isGptString" in message.content
+  ) {
+    const { content, ...rest } = message;
+    return {
+      ...rest,
+      strings: [],
+      children: [message.content],
+    };
+  }
+  if (typeof message.content === "string") {
+    return {
+      ...message,
+      strings: [message.content],
+      children: [],
+    };
+  }
+  if (Array.isArray(message.content)) {
+    return message as Message;
+  }
+  const { content, ...rest } = message;
+  return {
+    children: [],
+    strings: [],
+    ...rest,
+  };
+};

--- a/packages/openai/src/debug.ts
+++ b/packages/openai/src/debug.ts
@@ -36,10 +36,10 @@ async function writeToConsole(newContent: string) {
   latest = "";
   console.clear();
   await new Promise<void>((resolve) =>
-    process.stdout.cursorTo(0, 0, () => resolve())
+    process.stdout.cursorTo(0, 0, () => resolve()),
   );
   await new Promise<void>((resolve) =>
-    process.stdout.clearLine(0, () => resolve())
+    process.stdout.clearLine(0, () => resolve()),
   );
   console.log(currentLine);
 }
@@ -48,10 +48,10 @@ async function updateLatest(newContent: string) {
   latest = newContent;
   console.clear();
   await new Promise<void>((resolve) =>
-    process.stdout.cursorTo(0, 0, () => resolve())
+    process.stdout.cursorTo(0, 0, () => resolve()),
   );
   await new Promise<void>((resolve) =>
-    process.stdout.clearLine(0, () => resolve())
+    process.stdout.clearLine(0, () => resolve()),
   );
   console.log(currentLine + "\n" + latest);
 }
@@ -86,7 +86,7 @@ const getTableString = async <Options extends GPTOptions>({
           const color = values.get(v) || "white";
           // @ts-expect-error
           return `${colors[color].underline(`${v}`)}`;
-        })
+        }),
       );
       content = zip(strings, processedChildren).flat().join("");
     } else {
@@ -145,12 +145,12 @@ const getTableString = async <Options extends GPTOptions>({
             ...(typeof metadata.stream === "boolean" && !!metadata.stream
               ? [`streaming`]
               : []),
-          ].join(" ")
+          ].join(" "),
         ),
         hAlign: "right",
         colSpan: 2,
       },
-    ]
+    ],
   );
   return table.toString();
 };
@@ -180,7 +180,7 @@ export const debugStream = async <Options extends GPTOptions>({
       const { done, value } = await reader.read();
       if (done) break;
       const chunk = JSON.parse(
-        new TextDecoder().decode(value)
+        new TextDecoder().decode(value),
       ) as OpenAI.ChatCompletionChunk;
       chunk.choices.forEach((choice) => {
         strs[choice.index] =

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./tag.js";
 export * from "./variable.js";
+export { getOpenAIMessageParamFromMessage} from './utils.js'

--- a/packages/openai/src/index.ts
+++ b/packages/openai/src/index.ts
@@ -1,3 +1,3 @@
 export * from "./tag.js";
 export * from "./variable.js";
-export { getOpenAIMessageParamFromMessage} from './utils.js'
+export { getOpenAIMessageParamFromMessage } from "./utils.js";

--- a/packages/openai/src/tag.ts
+++ b/packages/openai/src/tag.ts
@@ -11,10 +11,10 @@ import type {
 } from "./types.js";
 import {
   getOpenAIMessageParamFromMessage,
-  getMessageFromInput,
   processArrayCallstack,
   processCallstack,
 } from "./utils.js";
+import { getMessageFromInput } from "./_unsafeUtils.js";
 import { DEFAULT_MODEL } from "./constants.js";
 import { ChatCompletionMessageParam } from "openai/resources/index";
 

--- a/packages/openai/src/utils.ts
+++ b/packages/openai/src/utils.ts
@@ -7,9 +7,9 @@ import {
   MessageInput,
   ParseFunction,
   TagValue,
+  Var,
 } from "./types.js";
 import { ChatCompletionMessageParam } from "openai/resources/chat/completions.mjs";
-import { Var } from "./variable.js";
 
 export function zip<T>(...arrays: T[][]): T[][] {
   // Find the length of the longest array
@@ -121,50 +121,4 @@ export const processArrayCallstack = async ({
     return values.map((value) => (parse ? parse(value) : value));
   }
   throw new Error(`Cannot call "${call?.method}" on GPTStringArray`);
-};
-
-export const getMessageFromInput = <Options extends GPTOptions>(
-  message: MessageInput<Options>,
-): Message => {
-  if (typeof message === "string") {
-    return {
-      role: "user" as const,
-      strings: [message],
-      children: [],
-    };
-  }
-  if ("_isGptString" in message) {
-    return {
-      role: "user" as const,
-      strings: [],
-      children: [message],
-    };
-  }
-  if (
-    typeof message.content === "function" &&
-    "_isGptString" in message.content
-  ) {
-    const { content, ...rest } = message;
-    return {
-      ...rest,
-      strings: [],
-      children: [message.content],
-    };
-  }
-  if (typeof message.content === "string") {
-    return {
-      ...message,
-      strings: [message.content],
-      children: [],
-    };
-  }
-  if (Array.isArray(message.content)) {
-    return message as Message;
-  }
-  const { content, ...rest } = message;
-  return {
-    children: [],
-    strings: [],
-    ...rest,
-  };
 };

--- a/packages/openai/src/utils.ts
+++ b/packages/openai/src/utils.ts
@@ -72,7 +72,7 @@ export const getOpenAIMessageParamFromMessage = async <
   Options extends GPTOptions,
 >(
   message: Message,
-  input: GetOptions<Options> | undefined,
+  input?: GetOptions<Options>,
 ): Promise<ChatCompletionMessageParam> => {
   if ("children" in message) {
     const processedChildren = await Promise.all(


### PR DESCRIPTION
I had to separate `getMessageFromInput` because it's not correctly typed. I have not enough context to fix that, but with this change, there should not be any behavior change except having the extra function exported.