### PR TITLE
feat: add getWithResponse

### DIFF
--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -10,7 +10,7 @@
     "gpt-3",
     "gpt-4"
   ],
-  "version": "0.0.10",
+  "version": "0.0.11-alpha.0",
   "license": "MIT",
   "exports": {
     ".": {

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -10,7 +10,7 @@
     "gpt-3",
     "gpt-4"
   ],
-  "version": "0.0.11-alpha.1",
+  "version": "0.0.11",
   "license": "MIT",
   "exports": {
     ".": {

--- a/packages/openai/package.json
+++ b/packages/openai/package.json
@@ -10,7 +10,7 @@
     "gpt-3",
     "gpt-4"
   ],
-  "version": "0.0.11-alpha.0",
+  "version": "0.0.11-alpha.1",
   "license": "MIT",
   "exports": {
     ".": {

--- a/packages/openai/src/__tests__/tag.ts
+++ b/packages/openai/src/__tests__/tag.ts
@@ -57,13 +57,20 @@ content: ${content}`;
     })
     .join("\n\n");
   if (stream) {
-    return getTestStreamFromResponse(
-      `\n  \n${input.replace(/^/gm, "  # ")}\n`,
-    ) as unknown as Stream<ChatCompletionChunk>;
+    return {
+      withResponse:() => ({
+        data: getTestStreamFromResponse(`\n  \n${input.replace(/^/gm, "  # ")}\n`) as unknown as Stream<ChatCompletionChunk>
+
+      })
+    }
   }
-  return openAICompletionFactory({
-    content: `\n  \n${input.replace(/^/gm, "  # ")}\n`,
-  });
+  return {
+    withResponse: () => ({
+      data: openAICompletionFactory({
+        content: `\n  \n${input.replace(/^/gm, "  # ")}\n`,
+      })
+    })
+  }
 }
 
 const mockOpenAI = jest.mocked(
@@ -102,11 +109,14 @@ describe("smoke tests", () => {
   });
 
   it("should get contents from mock OpenAI", async () => {
-    mockOpenAI.chat.completions.create.mockResolvedValue(
-      openAICompletionFactory({ content: "Hello, how are you?" }),
+    mockOpenAI.chat.completions.create.mockReturnValue(
+      {
+        //@ts-expect-error
+        withResponse: jest.fn().mockResolvedValue({ data: openAICompletionFactory({ content: "Hello, how are you?" })})
+      }
     );
     const base = openai.instance(mockOpenAI);
-    const result = await base`hi`.get();
+    const { data: result } = await base`hi`.get();
     expect(result).toMatchInlineSnapshot(`"Hello, how are you?"`);
   });
 
@@ -115,12 +125,15 @@ describe("smoke tests", () => {
       delayMs: 2,
     });
 
-    mockOpenAI.chat.completions.create.mockResolvedValue(
-      stream as unknown as Stream<ChatCompletionChunk>,
+    mockOpenAI.chat.completions.create.mockReturnValue(
+      {
+        //@ts-expect-error
+        withResponse: jest.fn().mockResolvedValue({ data: stream})
+      }
     );
 
     const base = openai.instance(mockOpenAI).stream(true);
-    const result = await base`hi`.get();
+    const { data: result } = await base`hi`.get();
     const response = await processStream(result);
     expect(response).toMatchInlineSnapshot(`"Hello, how are you?"`);
   });
@@ -132,15 +145,18 @@ describe("smoke tests", () => {
       delayMs: 2,
     });
 
-    mockOpenAI.chat.completions.create.mockResolvedValue(
-      stream as unknown as Stream<ChatCompletionChunk>,
+    mockOpenAI.chat.completions.create.mockReturnValue(
+      {
+        //@ts-expect-error
+        withResponse: jest.fn().mockResolvedValue({ data: stream})
+      }
     );
 
     const base = openai
       .instance(mockOpenAI)
       .stream(true)
       .addEvaluation(evaluation);
-    const result = await base`hi`.get();
+    const {data: result } = await base`hi`.get();
     const response = await processStream(result);
     expect(response).toMatchInlineSnapshot(`"Hello, how are you?"`);
     await new Promise(process.nextTick);
@@ -160,7 +176,7 @@ describe("smoke tests", () => {
     const lengthFn = Promise.resolve(`500 words`);
     expect(
       await processStream(
-        await message.get({
+        (await message.get({
           variables: {
             language,
             topic: topicFn,
@@ -171,7 +187,7 @@ describe("smoke tests", () => {
             // not defined, it will throw an error
             tone: base.user`Which tone should I use when talking to a ${variable("age")} year old? Respond with only a single word`,
           },
-        }),
+        })).data,
       ),
     ).toMatchInlineSnapshot(`
 "

--- a/packages/openai/src/tag.ts
+++ b/packages/openai/src/tag.ts
@@ -77,7 +77,7 @@ const makeGPTTag = <
   gpt.arrCallStack = new Array<{ method: string; args: any[] }>();
   gpt.callStack = new Array<{ method: string; args: any[] }>();
   gpt.parse = metadata.parse;
-  gpt.get = async function (
+  gpt.getWithResponse = async function (
     this: GPTString<Options>,
     input: GetOptions<Options> | undefined,
   ) {
@@ -220,6 +220,12 @@ const makeGPTTag = <
     });
     return this.cachedRun;
   };
+  gpt.get = async function (
+    this: GPTString<Options>,
+    input: GetOptions<Options> | undefined,
+  ) {
+    return (await this.getWithResponse(input)).data
+  }
 
   gpt.metadata = Object.assign({}, metadata || {});
   gpt.id = (id: string) => {

--- a/packages/openai/src/tag.ts
+++ b/packages/openai/src/tag.ts
@@ -102,7 +102,6 @@ const makeGPTTag = <
           max_tokens: maxTokens,
           stop,
           response_format: metadata.responseFormat,
-          stream_options: metadata.streamOptions
         };
         const stream = metadata.stream;
         if (!!stream) {
@@ -110,6 +109,7 @@ const makeGPTTag = <
             ...args,
             messages,
             stream: true,
+            stream_options: metadata.streamOptions
           }).withResponse();
           if (evaluations.length) {
             const [originalStream, streamForEvals] = openAIChatStream.tee();

--- a/packages/openai/src/tag.ts
+++ b/packages/openai/src/tag.ts
@@ -159,11 +159,11 @@ const makeGPTTag = <
           return resolve({ data: openAIChatStream, response });
         }
 
-        const choices = (
-          await instance.chat.completions.create({ ...args })
-        ).choices
+        const { data, response } = await instance.chat.completions.create({ ...args }).withResponse()
+        const choices = data.choices
           .slice(0, metadata.n ?? 1)
           .map(({ message }) => message.content);
+
         if (n === undefined) {
           const { parse } = this;
           const originalValue = choices[0] ?? null;
@@ -185,7 +185,7 @@ const makeGPTTag = <
           });
 
           // @ts-ignore
-          return resolve(value);
+          return resolve({ data: value, response });
         } else {
           const { parse } = this;
           const parsedValues = parse
@@ -210,8 +210,9 @@ const makeGPTTag = <
           this.callStack = [];
           this.arrCallStack = [];
           this.parse = undefined;
+
           // @ts-ignore
-          return resolve(value);
+          return resolve({ data: value, response });
         }
       } catch (error) {
         reject(error);

--- a/packages/openai/src/tag.ts
+++ b/packages/openai/src/tag.ts
@@ -101,7 +101,8 @@ const makeGPTTag = <
           messages,
           max_tokens: maxTokens,
           stop,
-          response_format: metadata.responseFormat
+          response_format: metadata.responseFormat,
+          stream_options: metadata.streamOptions
         };
         const stream = metadata.stream;
         if (!!stream) {
@@ -226,6 +227,10 @@ const makeGPTTag = <
   };
   gpt.temperature = (temperature: number) => {
     const tag = makeGPTTag<Options>({ ...gpt.metadata, temperature });
+    return tag;
+  };
+  gpt.streamOptions = (streamOptions: OpenAI.Chat.ChatCompletionCreateParams['stream_options']) => {
+    const tag = makeGPTTag<Options>({ ...gpt.metadata, streamOptions });
     return tag;
   };
   gpt.responseFormat = (responseFormat: OpenAI.Chat.ChatCompletionCreateParams['response_format']) => {

--- a/packages/openai/src/tag.ts
+++ b/packages/openai/src/tag.ts
@@ -106,11 +106,11 @@ const makeGPTTag = <
         };
         const stream = metadata.stream;
         if (!!stream) {
-          const openAIChatStream = await instance.chat.completions.create({
+          const { data: openAIChatStream, response } = await instance.chat.completions.create({
             ...args,
             messages,
             stream: true,
-          });
+          }).withResponse();
           if (evaluations.length) {
             const [originalStream, streamForEvals] = openAIChatStream.tee();
             originalStream.controller.signal.addEventListener("abort", (ev) => {
@@ -154,9 +154,9 @@ const makeGPTTag = <
 
             // @ts-ignore
             streamForEvals.toReadableStream().pipeTo(transformStream);
-            return resolve(originalStream);
+            return resolve({ data: originalStream, response });
           }
-          return resolve(openAIChatStream);
+          return resolve({ data: openAIChatStream, response });
         }
 
         const choices = (

--- a/packages/openai/src/types.ts
+++ b/packages/openai/src/types.ts
@@ -1,4 +1,5 @@
 import type { OpenAI } from "openai";
+import { APIPromise } from "openai/core.mjs";
 
 export interface Var<T extends string = string> {
   _isGptVariable: true;
@@ -186,12 +187,17 @@ export type AsyncIterableOpenAIStreamReturnTypes =
   | AsyncIterable<OpenAI.Chat.ChatCompletionChunk>
   | AsyncIterable<OpenAI.Completion>;
 
+type WithResponse<T> = {
+  data: T,
+  response: Awaited<ReturnType<APIPromise<OpenAI.Chat.Completions.ChatCompletionChunk>['withResponse']>>['response']
+}
+
 export type GetReturn<Options extends GPTOptions> =
-  Options["stream"] extends true
+  WithResponse<Options["stream"] extends true
     ? AsyncIterableOpenAIStreamReturnTypes
     : Options["n"] extends undefined
       ? Options["returns"]
-      : Options["returns"][];
+      : Options["returns"][]>;
 
 export type GetOptions<Options extends GPTOptions> = {
   variables: Record<

--- a/packages/openai/src/types.ts
+++ b/packages/openai/src/types.ts
@@ -259,6 +259,7 @@ export type GPTTagMetadata<Options extends GPTOptions> = {
   instance?: OpenAI;
   maxTokens?: number;
   responseFormat?: OpenAI.Chat.ChatCompletionCreateParams['response_format'];
+  streamOptions?: OpenAI.Chat.ChatCompletionCreateParams['stream_options'];
 };
 
 export type GPTString<Options extends GPTOptions> = GptStringImplementation<{
@@ -292,6 +293,9 @@ export type GPTString<Options extends GPTOptions> = GptStringImplementation<{
     metadata: GPTTagMetadata<Options>;
     temperature(
       temperature: NonNullable<GPTTagMetadata<Options>["temperature"]>,
+    ): GPTString<Options>;
+    streamOptions(
+      temperature: NonNullable<GPTTagMetadata<Options>["streamOptions"]>,
     ): GPTString<Options>;
     model(model: GPTTagMetadata<Options>["model"]): GPTString<Options>;
     /**

--- a/packages/openai/src/types.ts
+++ b/packages/openai/src/types.ts
@@ -193,11 +193,13 @@ type WithResponse<T> = {
 }
 
 export type GetReturn<Options extends GPTOptions> =
-  WithResponse<Options["stream"] extends true
+  Options["stream"] extends true
     ? AsyncIterableOpenAIStreamReturnTypes
     : Options["n"] extends undefined
       ? Options["returns"]
-      : Options["returns"][]>;
+      : Options["returns"][];
+
+export type GetReturnWithResponse<Options extends GPTOptions> = WithResponse<GetReturn<Options>>;
 
 export type GetOptions<Options extends GPTOptions> = {
   variables: Record<
@@ -208,16 +210,18 @@ export type GetOptions<Options extends GPTOptions> = {
 
 export type GptStringImplementation<Options extends GPTOptions> = {
   _isGptString: true;
-  cachedRun?: Promise<GetReturn<Options>>;
+  cachedRun?: Promise<GetReturnWithResponse<Options>>;
   parse?: ParseFunction<Options["returns"]>;
   callStack: { method: string; args: any[] }[];
   arrCallStack: { method: string; args: any[] }[];
 } & (Options["variables"] extends []
   ? {
+      getWithResponse(): Promise<GetReturnWithResponse<Options>>;
       get(): Promise<GetReturn<Options>>;
     }
   : {
-      get(options: GetOptions<Options>): Promise<GetReturn<Options>>;
+      getWithResponse(options: GetOptions<Options> | undefined): Promise<GetReturnWithResponse<Options>>;
+      get(options: GetOptions<Options> | undefined): Promise<GetReturn<Options>>;
     });
 
 export type ParseFunction<ReturnValue = unknown> = (

--- a/packages/openai/src/utils.ts
+++ b/packages/openai/src/utils.ts
@@ -60,7 +60,7 @@ export const getValueFromTagChild = async <Options extends GPTOptions>(
     return `${child}`;
   } else if (typeof child === "function") {
     if (isGPTString<Options>(child)) {
-      return `${await child.stream(false).get(input as GetOptions<Options>)}`;
+      return `${(await child.stream(false).get(input as GetOptions<Options>)).data}`;
     }
     return `${await getValueFromTagChild(child())}`;
   } else {

--- a/packages/openai/src/utils.ts
+++ b/packages/openai/src/utils.ts
@@ -60,7 +60,7 @@ export const getValueFromTagChild = async <Options extends GPTOptions>(
     return `${child}`;
   } else if (typeof child === "function") {
     if (isGPTString<Options>(child)) {
-      return `${(await child.stream(false).get(input as GetOptions<Options>)).data}`;
+      return `${(await child.stream(false).get(input as GetOptions<Options>))}`;
     }
     return `${await getValueFromTagChild(child())}`;
   } else {

--- a/packages/openai/src/utils.ts
+++ b/packages/openai/src/utils.ts
@@ -60,7 +60,7 @@ export const getValueFromTagChild = async <Options extends GPTOptions>(
     return `${child}`;
   } else if (typeof child === "function") {
     if (isGPTString<Options>(child)) {
-      return `${(await child.stream(false).get(input as GetOptions<Options>))}`;
+      return `${await child.stream(false).get(input as GetOptions<Options>)}`;
     }
     return `${await getValueFromTagChild(child())}`;
   } else {


### PR DESCRIPTION
~This PR is a breaking change~. This PR adds the method `getWithResponse` to retrieve the `rawResponse`. This is necessary to determine if a Portkey fallback happened or not.

Additionally, this PR adds another option for streaming which is necessary to get usage data: https://community.openai.com/t/usage-stats-now-available-when-using-streaming-with-the-chat-completions-api-or-completions-api/738156

EDIT: This is not a breaking change anymore, as `get` is just using  `getWithResponse`with directly selecting the data.